### PR TITLE
change placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # Security holding package
 
 This package contained malicious code and was removed from the registry by the npm security team. A placeholder was published to ensure users are not affected in the future.
-
-Please refer to www.npmjs.com/advisories?search={package-name} for more information.


### PR DESCRIPTION
 www.npmjs.com/advisories link is not exists anymore. Make link to GH advisories is not so simple.
Also advisories were not created for the looong time - big chance that there is no advisory anyway.
So let's change phrasing

