### PR TITLE
Add post install script informing about security holding packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,5 +2,8 @@
   "name": "XXXXXXXX",
   "version": "0.0.1-security",
   "description": "security holding package",
-  "repository": "npm/security-holder"
+  "repository": "npm/security-holder",
+  "scripts": {
+    "postinstall": "echo \"This is security holder. Package $PWD is no longer used.\"'"
+  }
 }


### PR DESCRIPTION
## Suggestion:

Inform the user that package has been compromised and replaced with security holder.

## Why?

Some of the packages get more than a million weekly downloads ([e.g. fs](https://www.npmjs.com/package/fs)). If a message was added the users could at least trim their dependencies and remove unnecessary downloads, slightly reducing global internet usage, electricity waste, etc